### PR TITLE
Add support for configurable render container and screen functions

### DIFF
--- a/src/Transitioner.js
+++ b/src/Transitioner.js
@@ -43,8 +43,7 @@ const defaultRenderScreen = (
 ) => (
   <Animated.View
     style={[{ ...StyleSheet.absoluteFillObject }, behindScreenStyles]}
-    pointerEvents={'auto'}
-    key={key}
+    pointerEvents={'auto'}    
   >
     <ScreenComponent
       transition={transition}
@@ -290,11 +289,11 @@ export class Transitioner extends React.Component {
           const renderFunc = descriptor.options.renderScreen || defaultRenderScreen;
           
           return (
-            <NavigationProvider value={descriptor.navigation}>              
+            <NavigationProvider key={key} value={descriptor.navigation}>              
               {renderFunc(C, transition, transitions, transitioningFromState,
                 transitionRouteKey ? navigation.state : null,
                 transitionRouteKey, descriptor.navigation, ref, 
-                behindScreenStyles)}
+                behindScreenStyles, key)}
             </NavigationProvider>            
           );
         }))}

--- a/src/Transitioner.js
+++ b/src/Transitioner.js
@@ -233,7 +233,7 @@ export class Transitioner extends React.Component {
       navState,
       descriptors,
     } = this.state;
-    const { navigationConfig, navigation } = this.props;
+    const { navigation } = this.props;
     const mainRouteKeys = navState.routes.map(r => r.key);
     let routeKeys = mainRouteKeys;
 
@@ -246,8 +246,7 @@ export class Transitioner extends React.Component {
     }
 
     // Use render container function from last route descriptor
-    const renderContainerFunc = navigationConfig && navigationConfig.navigationOptions
-      && navigationConfig.navigationOptions.renderContainer
+    const renderContainerFunc = descriptors[transitionRouteKey].options.renderContainer
       || defaultRenderContainer;
 
     return (

--- a/src/Transitioner.js
+++ b/src/Transitioner.js
@@ -57,7 +57,8 @@ const defaultRenderScreen = (
   </Animated.View>
 );
 
-const defaultRenderContainer = (children) => (
+const defaultRenderContainer = (transitionRouteKey, transitions, navigation,
+  transitioningFromState, transitionRouteKey, children) => (
   <React.Fragment>{children}</React.Fragment>
 );
 

--- a/src/Transitioner.js
+++ b/src/Transitioner.js
@@ -58,7 +58,7 @@ const defaultRenderScreen = (
 );
 
 const defaultRenderContainer = (transitionRouteKey, transitions, navigation,
-  transitioningFromState, transitionRouteKey, children) => (
+  transitioningFromState, transitioningToState, transitionRefs, children) => (
   <React.Fragment>{children}</React.Fragment>
 );
 

--- a/src/createStackTransitionNavigator.js
+++ b/src/createStackTransitionNavigator.js
@@ -4,5 +4,5 @@ import Transitioner from './Transitioner';
 export default function createStackTransitionNavigator(routeConfigs, options) {
   const router = StackRouter(routeConfigs, options);
 
-  return createNavigator(Transitioner, router);
+  return createNavigator(Transitioner, router, options);
 }


### PR DESCRIPTION
To be able to fully control how the surrounding container and each screen's container is rendered, I've added the option to specify this as two configurable members when setting up custom transitions. This can be used to wrap screens with libraries like `react-native-screens`. 

The new members are called `renderScreen` and `renderContainer`. Default implementations are provided.