### PR TITLE
Add support for a finishTransition callback.

### DIFF
--- a/src/Transitioner.js
+++ b/src/Transitioner.js
@@ -171,14 +171,14 @@ export class Transitioner extends React.Component {
     }
 
     const { finishTransition } = descriptor.options;
-    if(finishTransition) {
+    if (finishTransition) {
       await finishTransition(
         transition,
         this._transitionRefs,
         transitioningFromState,
         navState,
       );
-    }    
+    }
   }
 
   componentDidUpdate(lastProps, lastState) {

--- a/src/Transitioner.js
+++ b/src/Transitioner.js
@@ -169,6 +169,16 @@ export class Transitioner extends React.Component {
       // Navigation state prop has changed during the transtion! Schedule another transition
       this.setState(getStateForNavChange(this.props, state));
     }
+
+    const { finishTransition } = descriptor.options;
+    if(finishTransition) {
+      await finishTransition(
+        transition,
+        this._transitionRefs,
+        transitioningFromState,
+        navState,
+      );
+    }    
   }
 
   componentDidUpdate(lastProps, lastState) {


### PR DESCRIPTION
To be able to handle releasing resources and resetting any progress clocks a configurable callback has been added that will be called when state has changed and the transition is done.

This helps solving problems raised by the latest release in react-native-reanimated:
https://github.com/kmagiera/react-native-reanimated/pull/87