### PR TITLE
Run transition for first route

### DIFF
--- a/src/Transitioner.js
+++ b/src/Transitioner.js
@@ -109,6 +109,10 @@ export class Transitioner extends React.Component {
   _transitionRefs = {};
 
   static getDerivedStateFromProps = (props, state) => {
+    // Transition first route
+    if (state.isUnmounted) {
+      return getStateForNavChange(props, state);
+    }
     // Transition only happens when nav state changes
     if (props.navigation.state === state.navState) {
       return state;


### PR DESCRIPTION
We want to be able to play transitions for the first route in the stack. This pull request adds support for this.